### PR TITLE
Expand AST Parsing

### DIFF
--- a/capstone_project/backend/ast_coordinator.py
+++ b/capstone_project/backend/ast_coordinator.py
@@ -1,0 +1,30 @@
+import ast
+
+from capstone_project.backend.ast_supplier import ASTSupplier
+
+
+class ASTCoordinator:
+    """ ASTCoordinator is responsible for passing individual files
+    retrieved by the directory parser and then passing them on to
+    ASTSupplier. The goal is to spawn multiple threads each controlling
+    an ASTSupplier to improve static analysis for larger systems.
+    """
+    def __init__(self):
+        # TODO Redo this class and introduce multi-threading
+        self._ast_suppliers = None
+
+    def perform_static_analysis(self, files):
+        # Determine how many threads to create
+        self._create_ast_suppliers()
+
+        # Pass files to the spawned ASTSuppliers.
+        for file in files:
+            self._ast_suppliers.create_ast_from_file(file)
+            loops = ast.unparse(self._ast_suppliers.get_loop_nodes_for_file())
+            for loop in loops:
+                print(loop)
+
+    def _create_ast_suppliers(self):
+        self._ast_suppliers = ASTSupplier()
+
+

--- a/capstone_project/backend/ast_supplier.py
+++ b/capstone_project/backend/ast_supplier.py
@@ -3,16 +3,58 @@ import ast
 
 class ASTSupplier:
     def __init__(self):
-        self._content = []
+        self._node = None
+        self._loops = ast.For, ast.While, ast.AsyncFor
 
-    def create_ast_from_file(self, files):
-        for file in files:
-            with open(file, "rb") as f:
-                self._content.append(ast.parse(f.read()))
-
-    def print_parsed_ast(self):
-        for content in self._content:
-            print(ast.unparse(content))
+    def create_ast_from_file(self, file):
+        with open(file, "rb") as f:
+            self._node = ast.parse(f.read())
 
     def get_ast_list(self):
-        return self._content
+        return self._node
+
+    def get_loop_nodes_for_file(self):
+        """ Return the loop nodes from the created AST that
+        was generated for a specific file. Loop nodes are
+        defined as while, for, and async for loops.
+        """
+        # TODO We should update this to only include top level loops,
+        #      since if a loop contains another loop, we will already
+        #      have it from the top-level node being added.
+        nodes = ast.walk(self._node)
+        loop_nodes = []
+        for node in nodes:
+            if isinstance(node, self._loops):
+                loop_nodes.append(node)
+        return loop_nodes
+
+    def has_loop_nodes(self):
+        """ Returns True if for, while, or async for loops are detected.
+        """
+        nodes = ast.walk(self._node)
+        return any(isinstance(node, self._loops) for node in nodes)
+
+    def _print_parsed_ast(self):
+        """ Logging method to print the generated AST.
+        """
+        print(self._node.__dict__)
+
+    def _print_unparsed_ast(self):
+        """ Logging method to print the unparsed version of
+        the generated AST.
+        """
+        print(ast.unparse(self._node))
+
+
+if __name__ == '__main__':
+    # Functionality demonstration. This class will not contain a
+    # main method.
+    ast_test = ASTSupplier()
+    ast_test.create_ast_from_file("directory_parser.py")
+    ast_test._print_unparsed_ast()
+    ast_test._print_parsed_ast()
+    print(ast_test.has_loop_nodes())
+    file_loops = ast_test.get_loop_nodes_for_file()
+    print(file_loops)
+    for loop in file_loops:
+        print(ast.unparse(loop))


### PR DESCRIPTION
The purpose of this PR is to close Issue #3. AST parsing is extendible enough to be used in static code analysis. Specifically for SR, ASTs are being used to extract for, while, and async for loops from target files which can then be passed to SR calculators (when those are created).

There remain some limitations with the parsing that needs to be addressed. Currently, all loops are detected, but this includes sub-loops. Ideally, we should exclude these sub-loops to avoid unnecessary analysis as they will be analyzed when the top-level loop is analyzed. This should be created as a new issue to be addressed once this PR is merged. 

- Introduced a dummy ASTCoordinator class that will act as the controller is the interface and backend model (ASTSuppliers).
  - The goal of ASTCoordinator will be to spawn threads that will be bound to a single ASTSupplier. These bound suppliers will parse a subset of the files that have been requested for analysis to increase static analysis performance. For now, that multi-threading functionality is absent.
- Added additional logic to ASTSupplier to handle parsing out loops from a supplied file.